### PR TITLE
Added frontend:build to local:refresh task.

### DIFF
--- a/template/build/core/phing/tasks/local-sync.xml
+++ b/template/build/core/phing/tasks/local-sync.xml
@@ -1,6 +1,6 @@
 <project name="local" default="local:refresh">
 
-  <target name="local:refresh" description="Refreshes local environment from upstream testing database." depends="setup:build:all, local:sync, local:update"/>
+  <target name="local:refresh" description="Refreshes local environment from upstream testing database." depends="setup:build:all, frontend:build, local:sync, local:update"/>
 
   <target name="local:sync" description="Synchronize remote environment with local environment."
           depends="setup:drupal:settings">


### PR DESCRIPTION
`frontend:build` takes all the themes listed in `project.yml` and runs `npm run install-tools` and `npm run build`.

If no themes are listed, these tasks shouldn't run. The `npm run build` can be customized in a theme's `package.json` to run their own commands. For Nimbus, this is `npm install` and `gulp`.

There shouldn't be any reason not to include this.

Including this ensures that local devs always have the most up to date CSS files. Nimbus excludes these from the `develop` branch by default and builds them with Travis.