### PR TITLE
Make Bolt alias compatible with all Unix environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   - ./bolt.sh configure
   - ./bolt.sh create
   # Call targets in the new 'bolted' project.
-  - ../bolted8/bolt.sh build:validate:test -Dbehat.run-server=true -Dbehat.launch-phantom=true
+  - ../bolted8/bolt.sh build:validate:test -Dcreate_alias=false -Dbehat.run-server=true -Dbehat.launch-phantom=true
   # Deploy build artifact.
   - export DEPLOY_PR=true
   - ../bolted8/scripts/deploy/travis-deploy.sh 8.x 8.x-build

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -49,7 +49,7 @@ before_script:
   - git diff --exit-code
 
 script:
-  - ./bolt.sh -Dbehat.run-server=true -Dbehat.launch-phantom=true build:validate:test
+  - ./bolt.sh -Dbehat.run-server=true -Dcreate_alias=false -Dbehat.launch-phantom=true build:validate:test
 
 after_success:
   # Watch for successful build job on `master` branch; deploy to `master-build`.

--- a/template/build/core/phing/tasks/setup.xml
+++ b/template/build/core/phing/tasks/setup.xml
@@ -125,7 +125,15 @@
   </target>
 
   <target name="setup:bolt:alias" description="Installs the Bolt alias for command line usage.">
-    <exec dir="${repo.root}/scripts/bolt" command="./install-alias.sh" passthru="true" checkreturn="true"/>
+    <echo>Bolt can automatically create a Bash alias to make it easier to run Bolt tasks.</echo>
+    <echo>This alias may be created in .bash_profile or .bashrc depending on your system architecture.</echo>
+    <propertyprompt propertyName="create_alias" defaultValue="y" useExistingValue="true" promptText="Create a bash alias now? (y/n)" />
+    <if>
+      <equals arg1="${create_alias}" arg2="y"/>
+      <then>
+        <exec dir="${repo.root}/scripts/bolt" command="./install-alias.sh" passthru="true" checkreturn="true"/>
+      </then>
+    </if>
   </target>
 
 </project>

--- a/template/scripts/bolt/install-alias.sh
+++ b/template/scripts/bolt/install-alias.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 
-if [ -f ~/.bash_profile ]; then
-  if [ ! "`grep 'function bolt' ~/.bash_profile`" ]; then
-     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-     cat $DIR/alias >> ~/.bash_profile
-     echo "Added alias for bolt to ~/.bash_profile."
-     echo "Restart your terminal session to use the new command."
+if [ -f ~/.bashrc ]; then
+  if [ ! "`grep 'function bolt' ~/.bashrc`" ]; then
+    # Check for aliases in old-style .bash_profile.
+    # This check can be removed after everyone has moved to .bashrc.
+    if [ -f ~/.bash_profile ]; then
+      if [ "`grep 'function bolt' ~/.bash_profile`" ]; then
+        echo "Alias for bolt already exists in ~/.bash_profile"
+        exit
+      fi
+    fi
+    DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+    cat $DIR/alias >> ~/.bashrc
+    echo "Added alias for bolt to ~/.bashrc."
+    echo "Restart your terminal session to use the new command."
   else
-    echo "Alias for bolt already exists in ~/.bash_profile"
+    echo "Alias for bolt already exists in ~/.bashrc"
   fi
 else
-  echo "~/.bash_profile was not found. Could not install bolt alias."
+  echo "~/.bashrc was not found. Could not install bolt alias."
 fi

--- a/template/scripts/bolt/install-alias.sh
+++ b/template/scripts/bolt/install-alias.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 
-if [ -f ~/.bashrc ]; then
-  if [ ! "`grep 'function bolt' ~/.bashrc`" ]; then
-    # Check for aliases in old-style .bash_profile.
-    # This check can be removed after everyone has moved to .bashrc.
-    if [ -f ~/.bash_profile ]; then
-      if [ "`grep 'function bolt' ~/.bash_profile`" ]; then
-        echo "Alias for bolt already exists in ~/.bash_profile"
-        exit
-      fi
-    fi
-    DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-    cat $DIR/alias >> ~/.bashrc
-    echo "Added alias for bolt to ~/.bashrc."
-    echo "Restart your terminal session to use the new command."
-  else
-    echo "Alias for bolt already exists in ~/.bashrc"
+if [ "`basename "/$SHELL"`" = "zsh" ]; then
+  DETECTED_PROFILE="$HOME/.zshrc"
+elif [ -f "$HOME/.bashrc" ]; then
+  DETECTED_PROFILE="$HOME/.bashrc"
+elif [ -f "$HOME/.bash_profile" ]; then
+  DETECTED_PROFILE="$HOME/.bash_profile"
+elif [ -f "$HOME/.profile" ]; then
+  DETECTED_PROFILE="$HOME/.profile"
+fi
+
+if [ ! -z "$DETECTED_PROFILE" ]; then
+  if [ "`grep 'function bolt' $DETECTED_PROFILE`" ]; then
+    echo "Alias for bolt already exists in $DETECTED_PROFILE"
+    exit
   fi
+  DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+  cat $DIR/alias >> $DETECTED_PROFILE
+
+  echo "Added alias for bolt to $DETECTED_PROFILE"
+  echo "Restart your terminal session to use the new command."
 else
-  echo "~/.bashrc was not found. Could not install bolt alias."
+  echo "Could not install bolt alias. No profile found. Tried ~/.zshrc, ~/.bashrc, ~/.bash_profile and ~/.profile."
 fi


### PR DESCRIPTION
This is mostly just a string-replace of ~/.bash_profile (only exists on Mac, and includes .bashrc automatically) to ~/.bashrc (exists on all *nix environments).

I did add a bit of logic to accommodate anyone who is still using the old-style .bash_profile alias.