### PR TITLE
ACSF support for deploy step

### DIFF
--- a/template/build/core/phing/tasks/deploy.xml
+++ b/template/build/core/phing/tasks/deploy.xml
@@ -106,11 +106,13 @@
 
     <!-- Copy required files from docroot. -->
     <copy todir="${deploy.dir}/docroot" overwrite="true">
-      <fileset dir="${docroot}">
+      <fileset dir="${docroot}" defaultexcludes="false">
         <!-- This should be similar to .gitigore. -->
-        <include name="**"></include>
+        <!-- We remove default excludes because they include .gitignore files we need, like the ACSF one. -->
+        <include name="**" />
         <exclude name="**/local.*" />
         <exclude name=".gitkeep" />
+        <exclude name=".DS_STORE" />
         <exclude name="core/**" />
         <exclude name="drush/contrib/**" />
         <exclude name="example.gitignore" />
@@ -120,8 +122,8 @@
         <exclude name="themes/contrib/**" />
         <exclude name="profiles/contrib/**" />
         <exclude name="modules/contrib/**" />
-        <exclude name="**/node_modules/**"></exclude>
-        <exclude name="**/bower_components/**"></exclude>
+        <exclude name="**/node_modules/**" />
+        <exclude name="**/bower_components/**" />
       </fileset>
     </copy>
 

--- a/template/build/core/phing/tasks/deploy.xml
+++ b/template/build/core/phing/tasks/deploy.xml
@@ -51,6 +51,13 @@
 
   <target name="deploy:artifact:build" description="Generates a deploy-ready build in deploy.dir."
           depends="deploy:artifact:clean, deploy:artifact:copy, deploy:artifact:composer:install, deploy:artifact:profile:make, frontend:build, deploy:artifact:sanitize">
+    <!-- If we are using ACSF, run the ACSF Deploy command. -->
+    <if>
+      <equals arg1="${hosting}" arg2="acsf"/>
+      <then>
+        <phingcall target="deploy:acsf:init"/>
+      </then>
+    </if>
   </target>
 
   <target name="deploy:artifact:clean" description="Deletes the contents of the deploy dir.">
@@ -169,5 +176,10 @@
         <include name="**/CHANGELOG.txt"/>
       </fileset>
     </delete>
+  </target>
+
+  <target name="deploy:acsf:init" description="Re-initialize ACSF with the settings.php changes required for artifact.">
+    <chmod file="${deploy.dir}/docroot/sites/default/settings.php" mode="0755" />
+    <exec dir="${deploy.dir}/docroot" command="${drush.bin} --include=${deploy.dir}/docroot/modules/contrib/acsf/acsf_init acsf-init -y" logoutput="true" checkreturn="true"/>
   </target>
 </project>

--- a/template/build/core/phing/tasks/deploy.xml
+++ b/template/build/core/phing/tasks/deploy.xml
@@ -182,6 +182,6 @@
 
   <target name="deploy:acsf:init" description="Re-initialize ACSF with the settings.php changes required for artifact.">
     <chmod file="${deploy.dir}/docroot/sites/default/settings.php" mode="0755" />
-    <exec dir="${deploy.dir}/docroot" command="${drush.bin} --include=${deploy.dir}/docroot/modules/contrib/acsf/acsf_init acsf-init -y" logoutput="true" checkreturn="true"/>
+    <exec dir="${deploy.dir}/docroot" command="${drush.bin} --include=${deploy.dir}/docroot/modules/contrib/acsf/acsf_init acsf-init -r ${deploy.dir}/docroot -y" logoutput="true" checkreturn="true"/>
   </target>
 </project>

--- a/template/composer.json
+++ b/template/composer.json
@@ -10,7 +10,6 @@
   ],
   "require": {
     "composer/installers": "^1.0.20",
-    "drush/drush": "dev-master",
     "drupal/acquia_connector": "8.1.*",
     "drupal/acsf": "~8.1",
     "drupal/core": "~8",
@@ -28,6 +27,7 @@
     "behat/mink-goutte-driver":     "*",
     "behat/mink-selenium2-driver":  "*",
     "behat/mink-browserkit-driver": "*",
+    "drush/drush":                  "dev-master",
     "drupal/drupal-extension":      "~3.0",
     "drupal/coder":                 "~8.2",
     "phpunit/phpunit":              "4.6.*",
@@ -54,9 +54,6 @@
     "patches": {
       "drupal/core": {
         "Ignore front end vendor folders to improve directory search performance": "https://www.drupal.org/files/issues/ignore_front_end_vendor-2329453-116.patch"
-      },
-      "drupal/acsf": {
-        "Allow custom settings.php": "https://www.drupal.org/files/issues/acsf-2706365-2.patch"
       }
     }
   },

--- a/template/composer.lock
+++ b/template/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "92d817760d0e32a24b5840b4f58af46b",
-    "content-hash": "450655e95125dc65918a03816f7f39e0",
+    "hash": "454a40ad7ef39c67c0f9b6ae164e3641",
+    "content-hash": "353b63ede0316c6c68e97796502d7b18",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -931,9 +931,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-8.x-1.x": "8.1.x-dev"
-                },
-                "patches_applied": {
-                    "Allow custom settings.php": "https://www.drupal.org/files/issues/acsf-2706365-2.patch"
                 }
             },
             "notification-url": "https://packagist.drupal-composer.org/downloads/",
@@ -1070,16 +1067,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.1.0",
+            "version": "8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal-composer/drupal-core.git",
-                "reference": "78fb721295521bd9680731cf2a8287fb6e889afe"
+                "reference": "e405a10c85a874a70932fe53670993f790df746f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal-composer/drupal-core/zipball/78fb721295521bd9680731cf2a8287fb6e889afe",
-                "reference": "78fb721295521bd9680731cf2a8287fb6e889afe",
+                "url": "https://api.github.com/repos/drupal-composer/drupal-core/zipball/e405a10c85a874a70932fe53670993f790df746f",
+                "reference": "e405a10c85a874a70932fe53670993f790df746f",
                 "shasum": ""
             },
             "require": {
@@ -1223,10 +1220,8 @@
                     "Drupal\\Component\\": "lib/Drupal/Component",
                     "Drupal\\Driver\\": "../drivers/lib/Drupal/Driver"
                 },
-                "files": [
-                    "lib/Drupal.php"
-                ],
                 "classmap": [
+                    "lib/Drupal.php",
                     "lib/Drupal/Component/Utility/Timer.php",
                     "lib/Drupal/Component/Utility/Unicode.php",
                     "lib/Drupal/Core/Database/Database.php",
@@ -1240,7 +1235,7 @@
                 "GPL-2.0+"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2016-04-20 01:34:34"
+            "time": "2016-05-04 11:20:24"
         },
         {
             "name": "drupal/ctools",
@@ -2210,12 +2205,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "21689e6a690e416f0786988507855038929319a0"
+                "reference": "1d7380decef2fe54567f419d63f2b1ab701df558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/21689e6a690e416f0786988507855038929319a0",
-                "reference": "21689e6a690e416f0786988507855038929319a0",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/1d7380decef2fe54567f419d63f2b1ab701df558",
+                "reference": "1d7380decef2fe54567f419d63f2b1ab701df558",
                 "shasum": ""
             },
             "require": {
@@ -2305,7 +2300,7 @@
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2016-05-03 15:41:51"
+            "time": "2016-05-04 14:03:05"
         },
         {
             "name": "easyrdf/easyrdf",
@@ -6617,7 +6612,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phingofficial/phing/zipball/0d22158a12d09a53a067b4eb4ece5a17592c76a5",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/89ff14e9b9b70af5d186519b41a893f568790f2f",
                 "reference": "0ef30e55bb5871cb38903cc0ee9d76074118a22c",
                 "shasum": ""
             },
@@ -7295,16 +7290,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
+                "reference": "2292b116f43c272ff4328083096114f84ea46a56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/2292b116f43c272ff4328083096114f84ea46a56",
+                "reference": "2292b116f43c272ff4328083096114f84ea46a56",
                 "shasum": ""
             },
             "require": {
@@ -7341,7 +7336,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-02-26 18:40:46"
+            "time": "2016-05-04 07:59:13"
         },
         {
             "name": "sebastian/exporter",
@@ -7687,10 +7682,10 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "drush/drush": 20,
         "roave/security-advisories": 20,
         "drupal-composer/drupal-security-advisories": 20,
         "behat/mink": 0,
+        "drush/drush": 20,
         "phing/phing": 20
     },
     "prefer-stable": true,

--- a/template/docroot/sites/default/settings.php
+++ b/template/docroot/sites/default/settings.php
@@ -712,32 +712,13 @@ require DRUPAL_ROOT . '/sites/default/settings/logging.settings.php';
  * Acquia Cloud settings.
  */
 if ($is_ah_env && file_exists('/var/www/site-php')) {
+  require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
 
-  // This is ACSF. Below copied from acsf_init example settings.
-  if ($is_acsf) {
-    /**
-     * A user who gets here is trying to visit a site that is not yet registered
-     * with either the Site Factory or Hosting.
-     */
-
-    // Don't run any of this code if we are drush or a CLI script.
-    if (function_exists('drush_main') || !\Drupal::hasContainer() || PHP_SAPI === 'cli') {
-      if (!function_exists('drush_main')) {
-        header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
-      }
-      return;
-    }
-  }
-  // This is ACE.
-  else {
-    require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
-
-    // Store API Keys and things outside of version control.
-    // @see settings/sample-secrets.settings.php for sample code.
-    $secrets_file = sprintf('/mnt/gfs/%s.%s/secrets.settings.php', $_ENV['AH_SITE_GROUP'], $_ENV['AH_SITE_ENVIRONMENT']);
-    if (file_exists($secrets_file)) {
-      require $secrets_file;
-    }
+  // Store API Keys and things outside of version control.
+  // @see settings/sample-secrets.settings.php for sample code.
+  $secrets_file = sprintf('/mnt/gfs/%s.%s/secrets.settings.php', $_ENV['AH_SITE_GROUP'], $_ENV['AH_SITE_ENVIRONMENT']);
+  if (file_exists($secrets_file)) {
+    require $secrets_file;
   }
 }
 

--- a/template/project.yml
+++ b/template/project.yml
@@ -28,3 +28,8 @@ drush:
     remote: ${acquia_subname}.test
     # The local environment against which all local drush commands are run.
     local: self
+
+# Hosting environment flags.
+# Examples: acsf (Acquia Cloud Site Factory), ac (Acquia Cloud)
+# hosting: "acsf"
+# hosting: "ac"

--- a/template/readme/acsf-setup.md
+++ b/template/readme/acsf-setup.md
@@ -1,6 +1,7 @@
 # ACSF Setup
 
 To configure a project to run on ACSF, perform the following steps after initially setting up Bolt:
- 
+
+1. Add a `hosting` variable set to `acsf` in `project.yml`
 1. Execute `./bolt.sh acsf:init` from the project root.
 1. Add the acsf module as a dependency to your installation profile.

--- a/template/readme/acsf-setup.md
+++ b/template/readme/acsf-setup.md
@@ -5,3 +5,11 @@ To configure a project to run on ACSF, perform the following steps after initial
 1. Add a `hosting` variable set to `acsf` in `project.yml`
 1. Execute `./bolt.sh acsf:init` from the project root.
 1. Add the acsf module as a dependency to your installation profile.
+
+## Factory Hooks and settings.php
+
+Acquia Cloud Site Factory does not allow changes to `settings.php`. In order to make additions normally done with `settings.php`, factory hooks are used.
+
+Please see the documentation below for reference.
+
+[https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks](https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks)


### PR DESCRIPTION
- Add a flag in project.yml
- Add a deploy task that primarily copies settings.php needed for ACSF

We cannot re-use setup:acsf:init because it explicitly excludes the settings.php file for ACSF. It also runs against the local site, which doesn't work for deploy.

This allows us to use the default bolt setup for local dev and build an artifact that works on ACSF.