### PR TITLE
Make sure SSH key has 4096 bits

### DIFF
--- a/template/build/README.md
+++ b/template/build/README.md
@@ -38,7 +38,7 @@ Travis CI can be used to deploy a fully built site artifact (with the docroot) i
 1. A pull request is merged into the GitHub repository
 2. Travis builds the docroot
 3. Travis commits the docroot to a specific "build" branch and pushes to Acquia Cloud
-   
+
 To set up this workflow, you must configure Acquia Cloud, GitHub, and Travis CI to work together. Step-by-step instructions are provided below.
 
 
@@ -46,7 +46,7 @@ To set up this workflow, you must configure Acquia Cloud, GitHub, and Travis CI 
 
      ```
      cd ~/.ssh
-     ssh-keygen -t rsa
+     ssh-keygen -t rsa -b 4096
      ```
 
    Do not use a passphrase!


### PR DESCRIPTION
Acquia Insight throws the warning "The SSH key must be at least 4096 bits. Your SSH key is 2048 bits." if you don't add `-b 4096`.