### PR TITLE
Fix formatting for multi-line preformatted text.

### DIFF
--- a/template/build/README.md
+++ b/template/build/README.md
@@ -43,32 +43,40 @@ To set up this workflow, you must configure Acquia Cloud, GitHub, and Travis CI 
 
 
 1. Generate an SSH key locally. E.g.,
-   ````
-   cd ~/.ssh
-   ssh-keygen -t rsa
-   ````
+
+     ```
+     cd ~/.ssh
+     ssh-keygen -t rsa
+     ```
+
    Do not use a passphrase!
 1. Create a new Acquia Cloud account to be used exclusively as a container for the SSH keys that will grant Travis push access to Acquia Cloud. This can be done by inviting a new team member on the "Teams" tab in Acquia Cloud. You can use an email address like `<email>+travis@acquia.com`. The team member must have SSH push access.
 1. Login the your new Acquia Cloud account and add the public SSH key from the key pair that was generated in step 1 by visiting `https://accounts.acquia.com/account/[uid]/security`.
 1. Add the same public SSH key to the "Deployment Keys" section on your project's GitHub settings page, located at `https://github.com/acquia-pso/[project-name]/settings/keys`.
 1. Add the _private SSH key_ to your project's Travis CI settings located at `https://magnum.travis-ci.com/acquia-pso/[project-name]/settings`.
 1. Update your .travis.yml file to include the following lines:
-  ````
-   after_success:
-     - scripts/deploy/travis-deploy.sh build:validate:test develop develop-build
-  ````
+
+    ```
+     after_success:
+       - scripts/deploy/travis-deploy.sh build:validate:test develop develop-build
+    ```
+
   Note that two branch names are referenced in this example: "develop" and "develop-build". This example will watch for changes to the "develop" branch on GitHub and deploy a build artifact to the "develop-build" branch on Acquia Cloud when the 'build:validate:test' Travis job is successful.
 1. Add your cloud git repository to the remotes section of your project.yml file:
-  ````
-  remotes:
-     - example@svn-14671.prod.hosting.acquia.com:example.git`
-  ````
+
+    ```
+    remotes:
+       - example@svn-14671.prod.hosting.acquia.com:example.git`
+    ```
+
 1. Add your cloud git repository's server host name to `ssh_known_hosts` in you .travis.yml file.
-  ````
-  addons:
-    ssh_known_hosts:
-    - svn-14671.prod.hosting.acquia.com
-  ````
+
+    ```
+    addons:
+      ssh_known_hosts:
+      - svn-14671.prod.hosting.acquia.com
+    ```
+
 1. Commits or merges to the develop branch on GitHub should now trigger a fully built artifact to be deployed to your specified remotes.
 
 For information on manually deploying your project, read [readme/deploy.md](readme/deploy.md)


### PR DESCRIPTION
I noticed in the Markdown, the examples are on multiple lines, but when printed via GitHub's Markdown-to-HTML renderer, all the examples wrap on one line/inline.

Using this spacing makes the examples render correctly on GitHub (and should work with most any Markdown parser that renders ol/ul correctly).