### PR TITLE
Revert "Removing branch argument from deploy tasks."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - ../bolted8/bolt.sh build:validate:test -Dbehat.run-server=true -Dbehat.launch-phantom=true
   # Deploy build artifact.
   - export DEPLOY_PR=true
-  - ../bolted8/scripts/deploy/travis-deploy.sh 8.x
+  - ../bolted8/scripts/deploy/travis-deploy.sh 8.x 8.x-build
   # Validate and run 'bolt' phpunit tests.
   - phpcs --standard=../bolted8/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml tests
   - phpunit tests

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -53,6 +53,6 @@ script:
 
 after_success:
   # Watch for successful build job on `master` branch; deploy to `master-build`.
-  # - scripts/deploy/travis-deploy.sh master
+  # - scripts/deploy/travis-deploy.sh master master-build
   # Watch for successful build job on `develop` branch; deploy to `develop-build`.
-  # - scripts/deploy/travis-deploy.sh develop
+  # - scripts/deploy/travis-deploy.sh develop develop-build

--- a/template/build/core/phing/tasks/deploy.xml
+++ b/template/build/core/phing/tasks/deploy.xml
@@ -2,15 +2,16 @@
 
   <target name="deploy:artifact" description="Builds separate artifact and pushes to git.remotes defined project.yml.">
 
-    <!-- deploy.commitMsg must be passed as a param at runtime. -->
+    <!-- deploy.branch and deploy.commitMsg must be passed as params at runtime. -->
     <if>
       <or>
+        <not><isset property="deploy.branch"/></not>
         <not><isset property="deploy.commitMsg"/></not>
       </or>
       <then>
-        <fail>You must pass deploy.commitMsg as a runtime parameter.</fail>
+        <fail>You must pass deploy.branch and deploy.commitMsg as runtime parameters.</fail>
         <echo message="Command should match syntax:"/>
-        <echo message="./bolt.sh deploy:artifact -Ddeploy.commitMsg='BLT-123: The commit message.'"/>
+        <echo message="./bolt.sh deploy:artifact -Ddeploy.branch=8.x-build -Ddeploy.commitMsg='BLT-123: The commit message.'"/>
       </then>
     </if>
 
@@ -38,10 +39,8 @@
     <exec command="git remote add ${remoteName} ${deploy.remote}" dir="${deploy.dir}" logoutput="true" passthru="true"/>
     <exec command="git fetch ${remoteName}" dir="${deploy.dir}" logoutput="true" passthru="true"/>
 
-    <!-- Create the new branch, "[source-branch-name]-build". -->
-    <property name="deploy.branch" value="${git.current_branch}-build" />
+    <!-- Create the new branch. -->
     <exec command="git checkout -b ${deploy.branch}" dir="${deploy.dir}" logoutput="true" passthru="true"/>
-
     <!-- Pull the latest updates (if available). -->
     <exec command="git merge ${remoteName}/${deploy.branch}" dir="${deploy.dir}" logoutput="true" passthru="true"/>
   </target>

--- a/template/scripts/deploy/travis-deploy.sh
+++ b/template/scripts/deploy/travis-deploy.sh
@@ -3,7 +3,7 @@
 # What does this script do?
 # This script will watch for a Travis build on a specific
 # $source_branch on the canonical GitHub repository and deploy build artifacts
-# to [source-branch]-build on the git.remote specified in project.yml.
+# to $dest_branch on the git.remote specified in project.yml.
 
 # How to use this script?
 # This script should be executed in the `after_success` section of .travis.yml.
@@ -11,6 +11,7 @@
 # `scripts/deploy/travis-deploy.sh master master-build`
 
 source_branch=$1  # The branch to watch.
+dest_branch=$2    # The branch to which the build artifact should be committed and deployed.
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Note that the canonical repository is watched. Commits to forked repositories
@@ -26,7 +27,7 @@ if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]] || [[ "${DEPLOY_PR}" = "true" ]];
         echo "Build artifact will be deployed."
         commit_msg="Automated commit by Travis CI for Build #${TRAVIS_BUILD_ID}";
         # Call the `deploy` Phing target, passing in required parameters.
-        ${DIR}/../../bolt.sh deploy:artifact -Ddeploy.commitMsg="${commit_msg}";
+        ${DIR}/../../bolt.sh deploy:artifact -Ddeploy.branch="${dest_branch}" -Ddeploy.commitMsg="${commit_msg}";
       else
         echo "Build artifact will NOT be deployed for this branch."
     fi


### PR DESCRIPTION
Reverts acquia/bolt#42

Having issues where Travis cannot run commands to find the current branch. It only checks out a hash.