### PR TITLE
Improve Travis CI deployments.

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -51,8 +51,9 @@ before_script:
 script:
   - ./bolt.sh -Dbehat.run-server=true -Dbehat.launch-phantom=true build:validate:test
 
-after_success:
-  # Watch for successful build job on `master` branch; deploy to `master-build`.
-  # - scripts/deploy/travis-deploy.sh master
-  # Watch for successful build job on `develop` branch; deploy to `develop-build`.
-  # - scripts/deploy/travis-deploy.sh develop
+# deploy:
+#   provider: script
+#   script: scripts/deploy/travis-deploy.sh master master-build
+#   skip_cleanup: true
+#   on:
+#     branch: master


### PR DESCRIPTION
We've had automated deployments fail for a number of reasons lately, and it's a big problem because there's no way to proactively monitor for failed deploys. Because deployments happen in the `after_success` step, failures are ignored.

When I first [requested a fix](https://github.com/acquia/bolt-archive/issues/528) for this, there was unfortunately no alternative, but now there is :)

This PR dumps `after_success` and instead uses the new `deploy:provider:script` step, which will fail the build if deployment fails.

Note that we could also refactor travis-deploy.sh to not take any parameters or check for pull requests, since Travis handles this natively in the deploy step. But I didn't want to step on @damontgomery's toes as he works on #59, etc...