### PR TITLE
Add conditional around front:build so it will work without a theme.

### DIFF
--- a/template/build/core/phing/tasks/frontend.xml
+++ b/template/build/core/phing/tasks/frontend.xml
@@ -1,7 +1,12 @@
 <project name="frontend" default="frontend:install">
 
   <target name="frontend:build" depends="frontend:install" description="Uses gulp to build front end dependencies for all themes.">
-    <foreach list="${project.themes}" param="frontend.theme" target="frontend:build:run"/>
+    <if>
+      <isset property="project.themes"/>
+      <then>
+        <foreach list="${project.themes}" param="frontend.theme" target="frontend:build:run"/>
+      </then>
+    </if>
   </target>
 
   <target name="frontend:build:run" depends="frontend:install" description="Uses gulp to build front end dependencies for a theme.">


### PR DESCRIPTION
- Without this, tasks fail because it uses the string `${project.themes}` as the theme which doesn't exist.