### PR TITLE
Enable local Twig debugging

### DIFF
--- a/template/docroot/sites/default/settings/default.local.settings.php
+++ b/template/docroot/sites/default/settings/default.local.settings.php
@@ -30,7 +30,7 @@ $dir = dirname(DRUPAL_ROOT);
 $config_directories['sync'] = $dir . '/config/default';
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/sites/development.services.yml';
+$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
 
 /**
  * Assertions.


### PR DESCRIPTION
Addresses #85 

The below lines show the value of $dir being the project root, and not the docroot folder. Maybe this is a problem with the DRUPAL_ROOT value?
`$dir = dirname(DRUPAL_ROOT);`
`$config_directories['sync'] = $dir . '/config/default';`

This PR points to the development.services.yml file in the correct location.